### PR TITLE
Do Not Time Initial Step

### DIFF
--- a/execution/run.hpp
+++ b/execution/run.hpp
@@ -81,9 +81,12 @@ result run(CommGrid &&comm_grid, Stepper &&stepper, real_t tmax, real_t dt,
 
   auto step = stepper(n, delta, exchange);
 
+  if (tmax > 0)
+    step(state, dt); // do not measure execution time of inital step
+
   auto start = timer::now(backend_t{});
   real_t t;
-  for (t = 0; t < tmax; t += dt)
+  for (t = dt; t < tmax; t += dt)
     step(state, dt);
   auto stop = timer::now(backend_t{});
   double time = timer::duration(start, stop);


### PR DESCRIPTION
Overhead of the first time step might be large for communication backends (MPI setup time etc.), we do not want to measure this.