### PR TITLE
Fix Temporal Convergence of Crank-Nicolson Vertical Advection & Diffusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,9 @@ set(GTBENCH_RUNTIME "single_node" CACHE STRING "Runtime")
 set_property(CACHE GTBENCH_RUNTIME PROPERTY STRINGS "single_node" "simple_mpi" "gcl" "ghex_comm")
 
 set(GTBENCH_BPARAMS_HDIFF "" CACHE STRING "Parameters for GridTools backend for horizontal diffusion")
-set(GTBENCH_BPARAMS_VDIFF1 "" CACHE STRING "Parameters for GridTools backend for vertical diffusion (computation 1)")
-set(GTBENCH_BPARAMS_VDIFF2 "" CACHE STRING "Parameters for GridTools backend for vertical diffusion (computation 2)")
-set(GTBENCH_BPARAMS_RKADV1 "" CACHE STRING "Parameters for GridTools backend for Runge-Kutta advection step (computation 1)")
-set(GTBENCH_BPARAMS_RKADV2 "" CACHE STRING "Parameters for GridTools backend for Runge-Kutta advection step (computation 2)")
+set(GTBENCH_BPARAMS_VDIFF "" CACHE STRING "Parameters for GridTools backend for vertical diffusion")
+set(GTBENCH_BPARAMS_HADV "" CACHE STRING "Parameters for GridTools backend for horizontal advection")
+set(GTBENCH_BPARAMS_VADV "" CACHE STRING "Parameters for GridTools backend for vertical advection")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND GTBENCH_BACKEND STREQUAL "gpu")
   set(GT_CLANG_CUDA_MODE "Clang-CUDA" CACHE STRING "Clang-CUDA or NVCC-CUDA")

--- a/convergence_tests.cpp
+++ b/convergence_tests.cpp
@@ -32,31 +32,31 @@ int main(int argc, char **argv) {
 
   auto rt = runtime::init(rt_tag, args);
 
-  auto run_tests = [&rt,
-                    full_range](std::string const &title, auto const &exact,
-                                auto const &stepper, real_t tmax_spat_conv,
-                                std::size_t n_spat_conv, real_t tmax_temp_conv,
-                                std::size_t n_temp_conv) {
+  auto run_tests = [&rt, full_range](std::string const &title,
+                                     auto const &exact, auto const &stepper,
+                                     real_t tmax_spatial, std::size_t n_spatial,
+                                     real_t tmax_temporal,
+                                     std::size_t n_temporal) {
     std::cout << "=== " << title << " ===" << std::endl;
     std::cout << "Spatial convergence:" << std::endl;
     auto spatial_error_f = [&](std::size_t n) {
-      return runtime::solve(rt, exact, stepper, {n, n, n}, tmax_spat_conv,
-                            tmax_spat_conv / 100)
+      return runtime::solve(rt, exact, stepper, {n, n, n}, tmax_spatial,
+                            tmax_spatial / 100)
           .error;
     };
-    std::size_t n_min = full_range ? 2 : n_spat_conv / 2;
-    std::size_t n_max = full_range ? 128 : n_spat_conv;
+    std::size_t n_min = full_range ? 2 : n_spatial / 2;
+    std::size_t n_max = full_range ? 128 : n_spatial;
     verification::print_order_verification_result(
         verification::order_verification(spatial_error_f, n_min, n_max));
 
     std::cout << "Temporal convergence:" << std::endl;
     auto spacetime_error_f = [&](std::size_t n) {
-      return runtime::solve(rt, exact, stepper, {32, 32, 1024}, tmax_temp_conv,
-                            tmax_temp_conv / n)
+      return runtime::solve(rt, exact, stepper, {32, 32, 1024}, tmax_temporal,
+                            tmax_temporal / n)
           .error;
     };
-    n_min = full_range ? 2 : n_temp_conv / 2;
-    n_max = full_range ? 128 : n_temp_conv;
+    n_min = full_range ? 2 : n_temporal / 2;
+    n_max = full_range ? 128 : n_temporal;
     verification::print_order_verification_result(
         verification::order_verification(spacetime_error_f, n_min, n_max));
   };

--- a/convergence_tests.cpp
+++ b/convergence_tests.cpp
@@ -18,57 +18,77 @@ int main(int argc, char **argv) {
   constexpr auto rt_tag = runtime::GTBENCH_RUNTIME();
 
   options opts;
+  opts("mode", "fast (two grid sizes) or full-range run (many grid sizes)",
+       "{fast,full-range}", {"fast"});
   runtime::register_options(rt_tag, opts);
 
   auto args = opts.parse(argc, argv);
+  std::string mode = args.get<std::string>("mode");
+  if (mode != "fast" && mode != "full-range") {
+    std::cerr << "invalid value '" << mode << "' passed to --mode" << std::endl;
+    return 1;
+  }
+  bool full_range = mode == "full-range";
 
   auto rt = runtime::init(rt_tag, args);
 
-  auto run_tests = [&rt](std::string const &title, auto const &exact,
-                         auto const &stepper) {
+  auto run_tests = [&rt,
+                    full_range](std::string const &title, auto const &exact,
+                                auto const &stepper, real_t tmax_spat_conv,
+                                std::size_t n_spat_conv, real_t tmax_temp_conv,
+                                std::size_t n_temp_conv) {
     std::cout << "=== " << title << " ===" << std::endl;
     std::cout << "Spatial convergence:" << std::endl;
     auto spatial_error_f = [&](std::size_t n) {
-      real_t tmax = std::is_same<real_t, float>() ? 2e-2 : 1e-3;
-      return runtime::solve(rt, exact, stepper, {n, n, n}, tmax, tmax / 100)
+      return runtime::solve(rt, exact, stepper, {n, n, n}, tmax_spat_conv,
+                            tmax_spat_conv / 100)
           .error;
     };
-    std::size_t n = std::is_same<real_t, float>() ? 16 : 32;
+    std::size_t n_min = full_range ? 2 : n_spat_conv / 2;
+    std::size_t n_max = full_range ? 128 : n_spat_conv;
     verification::print_order_verification_result(
-        verification::order_verification(spatial_error_f, n / 2, n));
+        verification::order_verification(spatial_error_f, n_min, n_max));
 
     std::cout << "Temporal convergence:" << std::endl;
     auto spacetime_error_f = [&](std::size_t n) {
-      real_t tmax = std::is_same<real_t, float>() ? 1e-1 : 1e-2;
-      return runtime::solve(rt, exact, stepper, {128, 128, 128}, tmax, tmax / n)
+      return runtime::solve(rt, exact, stepper, {32, 32, 1024}, tmax_temp_conv,
+                            tmax_temp_conv / n)
           .error;
     };
+    n_min = full_range ? 2 : n_temp_conv / 2;
+    n_max = full_range ? 128 : n_temp_conv;
     verification::print_order_verification_result(
-        verification::order_verification(spacetime_error_f, 8, 16));
+        verification::order_verification(spacetime_error_f, n_min, n_max));
   };
 
-  const real_t diffusion_coeff = 0.05;
+  constexpr real_t diffusion_coeff = 0.05;
+  constexpr bool is_float = std::is_same<real_t, float>();
 
   run_tests("HORIZONTAL DIFFUSION",
             verification::analytical::horizontal_diffusion{diffusion_coeff},
-            numerics::hdiff_stepper(diffusion_coeff));
+            numerics::hdiff_stepper(diffusion_coeff), is_float ? 1e-1 : 1e-3,
+            is_float ? 16 : 32, 5e-1, 16);
   run_tests("VERTICAL DIFFUSION",
             verification::analytical::vertical_diffusion{diffusion_coeff},
-            numerics::vdiff_stepper(diffusion_coeff));
+            numerics::vdiff_stepper(diffusion_coeff), 5, 64, 100, 32);
   run_tests("FULL DIFFUSION",
             verification::analytical::full_diffusion{diffusion_coeff},
-            numerics::diff_stepper(diffusion_coeff));
+            numerics::diff_stepper(diffusion_coeff), is_float ? 1e-1 : 1e-3, 32,
+            5e-1, 16);
   run_tests("HORIZONTAL ADVECTION",
             verification::analytical::horizontal_advection{},
-            numerics::hadv_stepper());
-  run_tests("VERTICAL ADVECTION",
+            numerics::hadv_stepper(), is_float ? 1e-1 : 1e-4,
+            is_float ? 32 : 64, 1e-1, 16);
+  run_tests("VERTICAL ADVECTION", // needs even smaller vertical grid spacing
+                                  // for perfect 2nd order temporal convergence
             verification::analytical::vertical_advection{},
-            numerics::vadv_stepper());
+            numerics::vadv_stepper(), 1e-1, 128, 10, 32);
   run_tests("RUNGE-KUTTA ADVECTION", verification::analytical::full_advection{},
-            numerics::rkadv_stepper());
+            numerics::rkadv_stepper(), 1e-2, 64, 1, 8);
   run_tests("ADVECTION-DIFFUSION",
             verification::analytical::advection_diffusion{diffusion_coeff},
-            numerics::advdiff_stepper(diffusion_coeff));
+            numerics::advdiff_stepper(diffusion_coeff), is_float ? 1e-1 : 1e-3,
+            64, 1, is_float ? 16 : 64);
 
   return 0;
 }

--- a/convergence_tests.cpp
+++ b/convergence_tests.cpp
@@ -70,7 +70,8 @@ int main(int argc, char **argv) {
             is_float ? 16 : 32, 5e-1, 16);
   run_tests("VERTICAL DIFFUSION",
             verification::analytical::vertical_diffusion{diffusion_coeff},
-            numerics::vdiff_stepper(diffusion_coeff), 5, 64, 100, 32);
+            numerics::vdiff_stepper(diffusion_coeff), 5, 64, 50,
+            is_float ? 8 : 16);
   run_tests("FULL DIFFUSION",
             verification::analytical::full_diffusion{diffusion_coeff},
             numerics::diff_stepper(diffusion_coeff), is_float ? 1e-1 : 1e-3, 32,

--- a/numerics/CMakeLists.txt
+++ b/numerics/CMakeLists.txt
@@ -2,15 +2,14 @@ compile_as_cuda(advection.cpp diffusion.cpp)
 
 add_library(advection advection.cpp)
 target_compile_definitions(advection PRIVATE
-  GTBENCH_BPARAMS_RKADV1=${GTBENCH_BPARAMS_RKADV1}
-  GTBENCH_BPARAMS_RKADV2=${GTBENCH_BPARAMS_RKADV2}
-  )
+  GTBENCH_BPARAMS_HADV=${GTBENCH_BPARAMS_HADV}
+  GTBENCH_BPARAMS_VADV=${GTBENCH_BPARAMS_VADV}
+)
 target_link_libraries(advection common)
 
 add_library(diffusion diffusion.cpp)
 target_compile_definitions(diffusion PRIVATE
   GTBENCH_BPARAMS_HDIFF=${GTBENCH_BPARAMS_HDIFF}
-  GTBENCH_BPARAMS_VDIFF1=${GTBENCH_BPARAMS_VDIFF1}
-  GTBENCH_BPARAMS_VDIFF2=${GTBENCH_BPARAMS_VDIFF2}
+  GTBENCH_BPARAMS_VDIFF=${GTBENCH_BPARAMS_VDIFF}
 )
 target_link_libraries(diffusion common)

--- a/numerics/advection.cpp
+++ b/numerics/advection.cpp
@@ -117,8 +117,8 @@ struct stage_advection_w_forward {
   using d1 = inout_accessor<1, extent<0, 0, 0, 0, -1, 0>>;
   using d2 = inout_accessor<2, extent<0, 0, 0, 0, -1, 0>>;
 
-  using data = in_accessor<3, extent<0, 0, 0, 0, -1, 1>>;
-  using data_uncached = in_accessor<4, extent<0, 0, 0, 0, 0, infinite_extent>>;
+  using in = in_accessor<3, extent<0, 0, 0, 0, -1, 1>>;
+  using in_uncached = in_accessor<4, extent<0, 0, 0, 0, 0, infinite_extent>>;
 
   using dz = in_accessor<5>;
   using dt = in_accessor<6>;
@@ -126,7 +126,7 @@ struct stage_advection_w_forward {
   using k_size = in_accessor<8>;
 
   using param_list =
-      make_param_list<b, d1, d2, data, data_uncached, dz, dt, w, k_size>;
+      make_param_list<b, d1, d2, in, in_uncached, dz, dt, w, k_size>;
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::first_level) {
@@ -134,10 +134,10 @@ struct stage_advection_w_forward {
 
     real_t av = eval(-0.25_r / dz() * w());
     real_t bv = eval(1_r / dt() + 0.25_r * (w() - w(0, 0, 1)) / dz());
-    real_t d1v = eval(1_r / dt() * data() -
+    real_t d1v = eval(1_r / dt() * in() -
                       0.25_r / dz() *
-                          (w() * (data() - data_uncached(0, 0, k_offset)) +
-                           w(0, 0, 1) * (data(0, 0, 1) - data())));
+                          (w() * (in() - in_uncached(0, 0, k_offset)) +
+                           w(0, 0, 1) * (in(0, 0, 1) - in())));
     real_t d2v = -av;
 
     eval(b()) = bv;
@@ -151,9 +151,9 @@ struct stage_advection_w_forward {
     real_t bv = eval(1_r / dt() + 0.25_r * (w() - w(0, 0, 1)) / dz());
     real_t cv_km1 = -av;
     real_t d1v =
-        eval(1_r / dt() * data() - 0.25_r / dz() *
-                                       (w() * (data() - data(0, 0, -1)) +
-                                        w(0, 0, 1) * (data(0, 0, 1) - data())));
+        eval(1_r / dt() * in() - 0.25_r / dz() *
+                                     (w() * (in() - in(0, 0, -1)) +
+                                      w(0, 0, 1) * (in(0, 0, 1) - in())));
     real_t d2v = 0_r;
 
     real_t f = eval(av / b(0, 0, -1));
@@ -170,9 +170,9 @@ struct stage_advection_w_forward {
     real_t cv = eval(0.25_r / dz() * w(0, 0, 1));
     real_t cv_km1 = -av;
     real_t d1v =
-        eval(1_r / dt() * data() - 0.25_r / dz() *
-                                       (w() * (data() - data(0, 0, -1)) +
-                                        w(0, 0, 1) * (data(0, 0, 1) - data())));
+        eval(1_r / dt() * in() - 0.25_r / dz() *
+                                     (w() * (in() - in(0, 0, -1)) +
+                                      w(0, 0, 1) * (in(0, 0, 1) - in())));
     real_t d2v = -cv;
 
     real_t f = eval(av / b(0, 0, -1));
@@ -212,8 +212,8 @@ struct stage_advection_w_backward {
 struct stage_advection_w3 {
   using out = inout_accessor<0>;
   using out_top = inout_accessor<1, extent<0, 0, 0, 0, 0, 1>>;
-  using data = in_accessor<2, extent<0, 0, 0, 0, -infinite_extent, 0>>;
-  using data0 = in_accessor<3>;
+  using in = in_accessor<2, extent<0, 0, 0, 0, -infinite_extent, 0>>;
+  using in0 = in_accessor<3>;
   using d1 = in_accessor<4, extent<0, 0, 0, 0, -infinite_extent, 0>>;
   using d2 = in_accessor<5, extent<0, 0, 0, 0, -infinite_extent, 0>>;
 
@@ -223,7 +223,7 @@ struct stage_advection_w3 {
   using k_size = in_accessor<9>;
 
   using param_list =
-      make_param_list<out, out_top, data, data0, d1, d2, dz, dt, w, k_size>;
+      make_param_list<out, out_top, in, in0, d1, d2, dz, dt, w, k_size>;
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::last_level) {
@@ -233,21 +233,21 @@ struct stage_advection_w3 {
     real_t bv = eval(1_r / dt() + 0.25_r * (w() - w(0, 0, 1)) / dz());
     real_t cv = eval(0.25_r / dz() * w(0, 0, 1));
 
-    real_t d1v = eval(1_r / dt() * data() -
+    real_t d1v = eval(1_r / dt() * in() -
                       0.25_r / dz() *
-                          (w() * (data() - data(0, 0, -1)) +
-                           w(0, 0, 1) * (data(0, 0, -k_offset) - data())));
+                          (w() * (in() - in(0, 0, -1)) +
+                           w(0, 0, 1) * (in(0, 0, -k_offset) - in())));
 
     eval(out_top()) =
         eval((d1v - cv * d1(0, 0, -k_offset) - av * d1(0, 0, -1)) /
              (bv + cv * d2(0, 0, -k_offset) + av * d2(0, 0, -1)));
-    eval(out()) = eval(data0() + (out_top() - data()));
+    eval(out()) = eval(in0() + (out_top() - in()));
   }
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::modify<0, -1>) {
     eval(out_top()) = eval(out_top(0, 0, 1));
-    eval(out()) = eval(data0() + (d1() + d2() * out_top() - data()));
+    eval(out()) = eval(in0() + (d1() + d2() * out_top() - in()));
   }
 };
 

--- a/numerics/advection.cpp
+++ b/numerics/advection.cpp
@@ -290,14 +290,13 @@ vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta) {
   };
 
   auto field = storage_builder(resolution);
-  auto d1 = field();
   auto d2 = field();
 
-  return [grid = std::move(grid), spec = std::move(spec), d1 = std::move(d1),
-          d2 = std::move(d2), delta,
-          resolution](storage_t out, storage_t in, storage_t in0, storage_t w,
-                      real_t dt) {
-    gt::stencil::run(spec, backend_t<>(), grid, out, in, in, in0, w, d1, d2,
+  return [grid = std::move(grid), spec = std::move(spec), d2 = std::move(d2),
+          delta, resolution](storage_t out, storage_t in, storage_t in0,
+                             storage_t w, real_t dt) {
+    gt::stencil::run(spec, backend_t<>(), grid, out, in, in, in0, w,
+                     out /* out is used as temporary storage for d1 */, d2,
                      gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),
                      gt::stencil::make_global_parameter(dt));

--- a/numerics/advection.cpp
+++ b/numerics/advection.cpp
@@ -290,13 +290,14 @@ vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta) {
   };
 
   auto field = storage_builder(resolution);
+  auto d1 = field();
   auto d2 = field();
 
-  return [grid = std::move(grid), spec = std::move(spec), d2 = std::move(d2),
-          delta, resolution](storage_t out, storage_t in, storage_t in0,
-                             storage_t w, real_t dt) {
-    gt::stencil::run(spec, backend_t<>(), grid, out, in, in, in0, w,
-                     out /* out is used as temporary storage for d1 */, d2,
+  return [grid = std::move(grid), spec = std::move(spec), d1 = std::move(d1),
+          d2 = std::move(d2), delta,
+          resolution](storage_t out, storage_t in, storage_t in0, storage_t w,
+                      real_t dt) {
+    gt::stencil::run(spec, backend_t<>(), grid, out, in, in, in0, w, d1, d2,
                      gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),
                      gt::stencil::make_global_parameter(dt));

--- a/numerics/advection.cpp
+++ b/numerics/advection.cpp
@@ -260,11 +260,11 @@ horizontal(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta) {
   return [grid = std::move(grid), delta](storage_t out, storage_t in,
                                          storage_t in0, storage_t u,
                                          storage_t v, real_t dt) {
-    gt::stencil::run_single_stage(stage_horizontal(), backend_t<>(), grid, out,
-                                  in, in0, u, v,
-                                  gt::stencil::make_global_parameter(delta.x),
-                                  gt::stencil::make_global_parameter(delta.y),
-                                  gt::stencil::make_global_parameter(dt));
+    gt::stencil::run_single_stage(
+        stage_horizontal(), backend_t<GTBENCH_BPARAMS_HADV>(), grid, out, in,
+        in0, u, v, gt::stencil::make_global_parameter(delta.x),
+        gt::stencil::make_global_parameter(delta.y),
+        gt::stencil::make_global_parameter(dt));
   };
 }
 
@@ -297,7 +297,8 @@ vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta) {
           d2 = std::move(d2), delta,
           resolution](storage_t out, storage_t in, storage_t in0, storage_t w,
                       real_t dt) {
-    gt::stencil::run(spec, backend_t<>(), grid, out, in, in, in0, w, d1, d2,
+    gt::stencil::run(spec, backend_t<GTBENCH_BPARAMS_VADV>(), grid, out, in, in,
+                     in0, w, d1, d2,
                      gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),
                      gt::stencil::make_global_parameter(dt));

--- a/numerics/advection.cpp
+++ b/numerics/advection.cpp
@@ -176,7 +176,7 @@ struct stage_advection_w_forward {
     real_t d2v = -cv;
 
     real_t f = eval(av / b(0, 0, -1));
-    eval(b()) = bv - f * cv;
+    eval(b()) = bv - f * cv_km1;
     eval(d1()) = eval(d1v - f * d1(0, 0, -1));
     eval(d2()) = eval(d2v - f * d2(0, 0, -1));
   }

--- a/numerics/advection.hpp
+++ b/numerics/advection.hpp
@@ -14,7 +14,8 @@
 namespace numerics {
 namespace advection {
 
-std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t, real_t)>
+std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t,
+                   real_t)>
 horizontal(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta);
 
 std::function<void(storage_t, storage_t, storage_t, storage_t, real_t)>

--- a/numerics/advection.hpp
+++ b/numerics/advection.hpp
@@ -14,8 +14,7 @@
 namespace numerics {
 namespace advection {
 
-std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t,
-                   real_t)>
+std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t, real_t)>
 horizontal(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta);
 
 std::function<void(storage_t, storage_t, storage_t, storage_t, real_t)>

--- a/numerics/advection.hpp
+++ b/numerics/advection.hpp
@@ -14,16 +14,11 @@
 namespace numerics {
 namespace advection {
 
-std::function<void(storage_t, storage_t, storage_t, storage_t, real_t)>
+std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t, real_t)>
 horizontal(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta);
 
-std::function<void(storage_t, storage_t, storage_t, real_t)>
+std::function<void(storage_t, storage_t, storage_t, storage_t, real_t)>
 vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta);
-
-std::function<void(storage_t, storage_t, storage_t, storage_t, storage_t,
-                   storage_t, real_t)>
-runge_kutta_step(vec<std::size_t, 3> const &resolution,
-                 vec<real_t, 3> const &delta);
 
 } // namespace advection
 } // namespace numerics

--- a/numerics/diffusion.cpp
+++ b/numerics/diffusion.cpp
@@ -246,14 +246,12 @@ vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta,
   };
 
   auto field = storage_builder(resolution);
-  auto d1 = field();
   auto d2 = field();
 
-  return [grid = std::move(grid), spec = std::move(spec), d1 = std::move(d1),
-          d2 = std::move(d2), delta, resolution,
-          coeff](storage_t out, storage_t in, real_t dt) {
+  return [grid = std::move(grid), spec = std::move(spec), d2 = std::move(d2),
+          delta, resolution, coeff](storage_t out, storage_t in, real_t dt) {
     gt::stencil::run(spec, backend_t<GTBENCH_BPARAMS_VDIFF1>(), grid, out, in,
-                     in, d1, d2,
+                     in, out /* out is used as temporary storage d1 */, d2,
                      gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),
                      gt::stencil::make_global_parameter(dt),

--- a/numerics/diffusion.cpp
+++ b/numerics/diffusion.cpp
@@ -75,8 +75,8 @@ struct stage_diffusion_w_forward {
   using d1 = inout_accessor<1, extent<0, 0, 0, 0, -1, 0>>;
   using d2 = inout_accessor<2, extent<0, 0, 0, 0, -1, 0>>;
 
-  using data = in_accessor<3, extent<0, 0, 0, 0, -1, 1>>;
-  using data_uncached = in_accessor<4, extent<0, 0, 0, 0, 0, infinite_extent>>;
+  using in = in_accessor<3, extent<0, 0, 0, 0, -1, 1>>;
+  using in_uncached = in_accessor<4, extent<0, 0, 0, 0, 0, infinite_extent>>;
 
   using dz = in_accessor<5>;
   using dt = in_accessor<6>;
@@ -84,7 +84,7 @@ struct stage_diffusion_w_forward {
   using k_size = in_accessor<8>;
 
   using param_list =
-      make_param_list<b, d1, d2, data, data_uncached, dz, dt, coeff, k_size>;
+      make_param_list<b, d1, d2, in, in_uncached, dz, dt, coeff, k_size>;
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::first_level) {
@@ -92,10 +92,10 @@ struct stage_diffusion_w_forward {
 
     real_t av = eval(-coeff() / (2_r * dz() * dz()));
     real_t bv = eval(1_r / dt() + coeff() / (dz() * dz()));
-    real_t d1v = eval(1_r / dt() * data() + 0.5_r * coeff() *
-                                                (data_uncached(0, 0, k_offset) -
-                                                 2_r * data() + data(0, 0, 1)) /
-                                                (dz() * dz()));
+    real_t d1v = eval(1_r / dt() * in() + 0.5_r * coeff() *
+                                              (in_uncached(0, 0, k_offset) -
+                                               2_r * in() + in(0, 0, 1)) /
+                                              (dz() * dz()));
     real_t d2v = -av;
 
     eval(b()) = bv;
@@ -109,9 +109,9 @@ struct stage_diffusion_w_forward {
     real_t bv = eval(1_r / dt() + coeff() / (dz() * dz()));
     real_t cv = av;
     real_t d1v =
-        eval(1_r / dt() * data() +
-             0.5_r * coeff() * (data(0, 0, -1) - 2_r * data() + data(0, 0, 1)) /
-                 (dz() * dz()));
+        eval(1_r / dt() * in() + 0.5_r * coeff() *
+                                     (in(0, 0, -1) - 2_r * in() + in(0, 0, 1)) /
+                                     (dz() * dz()));
     real_t d2v = 0_r;
 
     real_t f = eval(av / b(0, 0, -1));
@@ -127,9 +127,9 @@ struct stage_diffusion_w_forward {
     real_t bv = eval(1_r / dt() + coeff() / (dz() * dz()));
     real_t cv = av;
     real_t d1v =
-        eval(1_r / dt() * data() +
-             0.5_r * coeff() * (data(0, 0, -1) - 2_r * data() + data(0, 0, 1)) /
-                 (dz() * dz()));
+        eval(1_r / dt() * in() + 0.5_r * coeff() *
+                                     (in(0, 0, -1) - 2_r * in() + in(0, 0, 1)) /
+                                     (dz() * dz()));
     real_t d2v = -cv;
 
     real_t f = eval(av / b(0, 0, -1));
@@ -169,7 +169,7 @@ struct stage_diffusion_w_backward {
 struct stage_diffusion_w3 {
   using out = inout_accessor<0>;
   using out_top = inout_accessor<1, extent<0, 0, 0, 0, 0, 1>>;
-  using data = in_accessor<2, extent<0, 0, 0, 0, -infinite_extent, 0>>;
+  using in = in_accessor<2, extent<0, 0, 0, 0, -infinite_extent, 0>>;
   using d1 = in_accessor<3, extent<0, 0, 0, 0, -infinite_extent, 0>>;
   using d2 = in_accessor<4, extent<0, 0, 0, 0, -infinite_extent, 0>>;
 
@@ -179,7 +179,7 @@ struct stage_diffusion_w3 {
   using k_size = in_accessor<8>;
 
   using param_list =
-      make_param_list<out, out_top, data, d1, d2, dz, dt, coeff, k_size>;
+      make_param_list<out, out_top, in, d1, d2, dz, dt, coeff, k_size>;
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::last_level) {
@@ -188,10 +188,10 @@ struct stage_diffusion_w3 {
     real_t av = eval(-coeff() / (2_r * dz() * dz()));
     real_t bv = eval(1_r / dt() + coeff() / (dz() * dz()));
     real_t cv = av;
-    real_t d1v = eval(1_r / dt() * data() + 0.5_r * coeff() *
-                                                (data(0, 0, -1) - 2_r * data() +
-                                                 data(0, 0, -k_offset)) /
-                                                (dz() * dz()));
+    real_t d1v = eval(1_r / dt() * in() +
+                      0.5_r * coeff() *
+                          (in(0, 0, -1) - 2_r * in() + in(0, 0, -k_offset)) /
+                          (dz() * dz()));
 
     eval(out_top()) =
         eval((d1v - cv * d1(0, 0, -k_offset) - av * d1(0, 0, -1)) /

--- a/numerics/diffusion.cpp
+++ b/numerics/diffusion.cpp
@@ -250,7 +250,7 @@ vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta,
 
   return [grid = std::move(grid), spec = std::move(spec), d2 = std::move(d2),
           delta, resolution, coeff](storage_t out, storage_t in, real_t dt) {
-    gt::stencil::run(spec, backend_t<GTBENCH_BPARAMS_VDIFF1>(), grid, out, in,
+    gt::stencil::run(spec, backend_t<GTBENCH_BPARAMS_VDIFF>(), grid, out, in,
                      in, out /* out is used as temporary storage d1 */, d2,
                      gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),

--- a/numerics/diffusion.cpp
+++ b/numerics/diffusion.cpp
@@ -71,132 +71,131 @@ struct stage_horizontal {
 };
 
 struct stage_diffusion_w_forward {
-  using c = inout_accessor<0, extent<0, 0, 0, 0, -1, 0>>;
-  using d = inout_accessor<1, extent<0, 0, 0, 0, -1, 0>>;
-  using c2 = inout_accessor<2, extent<0, 0, 0, 0, -1, 0>>;
-  using d2 = inout_accessor<3, extent<0, 0, 0, 0, -1, 0>>;
+  using b = inout_accessor<0, extent<0, 0, 0, 0, -1, 0>>;
+  using d1 = inout_accessor<1, extent<0, 0, 0, 0, -1, 0>>;
+  using d2 = inout_accessor<2, extent<0, 0, 0, 0, -1, 0>>;
 
-  using data = in_accessor<4, extent<0, 0, 0, 0, -1, 1>>;
-  using data_uncached =
-      in_accessor<5, extent<0, 0, 0, 0, -infinite_extent, infinite_extent>>;
+  using data = in_accessor<3, extent<0, 0, 0, 0, -1, 1>>;
+  using data_uncached = in_accessor<4, extent<0, 0, 0, 0, 0, infinite_extent>>;
 
-  using dz = in_accessor<6>;
-  using dt = in_accessor<7>;
-  using coeff = in_accessor<8>;
-
-  using k_size = in_accessor<9>;
+  using dz = in_accessor<5>;
+  using dt = in_accessor<6>;
+  using coeff = in_accessor<7>;
+  using k_size = in_accessor<8>;
 
   using param_list =
-      make_param_list<c, d, c2, d2, data, data_uncached, dz, dt, coeff, k_size>;
+      make_param_list<b, d1, d2, data, data_uncached, dz, dt, coeff, k_size>;
 
   template <typename Evaluation>
   GT_FUNCTION static void apply(Evaluation eval, full_t::first_level) {
     auto k_offset = eval(k_size()) - 1;
 
-    auto ac = eval(-coeff() / (2_r * dz() * dz()));
-    auto b = eval(1_r / dt() - 2 * ac);
-
-    eval(d()) = eval(1_r / dt() * data() + 0.5_r * coeff() *
-                                               (data_uncached(0, 0, k_offset) -
-                                                2_r * data() + data(0, 0, 1)) /
-                                               (dz() * dz()));
-
-    b *= 2;
-    eval(c()) = ac / b;
-    eval(d()) = eval(d() / b);
-
-    eval(c2()) = eval(c() / b);
-    eval(d2()) = -0.5_r;
+    auto a = eval(-coeff() / (2_r * dz() * dz()));
+    eval(b()) = eval(1_r / dt() - 2 * a);
+    auto c = a;
+    eval(d1()) = eval(1_r / dt() * data() + 0.5_r * coeff() *
+                                                (data_uncached(0, 0, k_offset) -
+                                                 2_r * data() + data(0, 0, 1)) /
+                                                (dz() * dz()));
+    eval(d2()) = -a;
   }
 
   template <typename Evaluation>
-  GT_FUNCTION static void apply(Evaluation eval, full_t::modify<1, -1>) {
-    auto ac = eval(-coeff() / (2_r * dz() * dz()));
-    auto b = eval(1_r / dt() - 2 * ac);
-
-    eval(d()) =
+  GT_FUNCTION static void apply(Evaluation eval, full_t::modify<1, -2>) {
+    auto a = eval(-coeff() / (2_r * dz() * dz()));
+    auto c = a;
+    auto w = eval(a / b(0, 0, -1));
+    eval(b()) = eval(1_r / dt() - 2 * a - w * c);
+    eval(d1()) =
         eval(1_r / dt() * data() +
              0.5_r * coeff() * (data(0, 0, -1) - 2_r * data() + data(0, 0, 1)) /
-                 (dz() * dz()));
-
-    eval(c()) = eval(ac / (b - c(0, 0, -1) * ac));
-    eval(d()) = eval((d() - ac * d(0, 0, -1)) / (b - c(0, 0, -1) * ac));
-
-    eval(c2()) = eval(c() / (b - c2(0, 0, -1) * ac));
-    eval(d2()) = eval((-ac * d2(0, 0, -1)) / (b - c2(0, 0, -1) * ac));
+                 (dz() * dz()) -
+             w * d1(0, 0, -1));
+    eval(d2()) = eval(-w * d2(0, 0, -1));
   }
+
   template <typename Evaluation>
-  GT_FUNCTION static void apply(Evaluation eval, full_t::last_level) {
-    auto k_offset = eval(k_size()) - 1;
-
-    auto ac = eval(-coeff() / (2_r * dz() * dz()));
-    auto b = eval(1_r / dt() - 2 * ac);
-
-    eval(d()) =
-        eval(1_r / dt() * data() + 0.5_r * coeff() *
-                                       (data(0, 0, -1) - 2_r * data() +
-                                        data_uncached(0, 0, -k_offset)) /
-                                       (dz() * dz()));
-
-    b += ac * ac / b;
-    eval(c()) = eval(ac / (b - c(0, 0, -1) * ac));
-    eval(d()) = eval((d() - ac * d(0, 0, -1)) / (b - c(0, 0, -1) * ac));
-
-    eval(c2()) = eval(c() / (b - c2(0, 0, -1) * ac));
-    eval(d2()) = eval((ac - ac * d2(0, 0, -1)) / (b - c2(0, 0, -1) * ac));
+  GT_FUNCTION static void apply(Evaluation eval,
+                                full_t::last_level::shift<-1>) {
+    auto a = eval(-coeff() / (2_r * dz() * dz()));
+    auto c = a;
+    auto w = eval(a / b(0, 0, -1));
+    eval(b()) = eval(1_r / dt() - 2 * a - w * c);
+    eval(d1()) =
+        eval(1_r / dt() * data() +
+             0.5_r * coeff() * (data(0, 0, -1) - 2_r * data() + data(0, 0, 1)) /
+                 (dz() * dz()) -
+             w * d1(0, 0, -1));
+    eval(d2()) = eval(-c - w * d2(0, 0, -1));
   }
 };
+
 struct stage_diffusion_w_backward {
-  using c = inout_accessor<0>;
-  using d = inout_accessor<1, extent<0, 0, 0, 0, 0, 1>>;
-  using c2 = inout_accessor<2>;
-  using d2 = inout_accessor<3, extent<0, 0, 0, 0, 0, 1>>;
+  using b = in_accessor<0>;
+  using d1 = inout_accessor<1, extent<0, 0, 0, 0, 0, 1>>;
+  using d2 = inout_accessor<2, extent<0, 0, 0, 0, 0, 1>>;
 
-  using fact = inout_accessor<4>;
+  using dz = in_accessor<3>;
+  using coeff = in_accessor<4>;
 
-  using d_uncached = in_accessor<5, extent<0, 0, 0, 0, 0, infinite_extent>>;
-  using d2_uncached = in_accessor<6, extent<0, 0, 0, 0, 0, infinite_extent>>;
-
-  using dz = in_accessor<7>;
-  using dt = in_accessor<8>;
-  using coeff = in_accessor<9>;
-  using k_size = in_accessor<10>;
-
-  using param_list = make_param_list<c, d, c2, d2, fact, d_uncached,
-                                     d2_uncached, dz, dt, coeff, k_size>;
+  using param_list = make_param_list<b, d1, d2, dz, coeff>;
 
   template <typename Evaluation>
-  GT_FUNCTION static void apply(Evaluation eval, full_t::first_level) {
-    auto k_offset = eval(k_size() - 1);
-    auto beta = eval(-coeff() / (2_r * dz() * dz()));
-    auto gamma = -eval(1_r / dt() - 2 * beta);
-
-    eval(d()) = eval(d() - c() * d(0, 0, 1));
-    eval(d2()) = eval(d2() - c2() * d2(0, 0, 1));
-
-    eval(fact()) =
-        eval((d() + beta * d_uncached(0, 0, k_offset) / gamma) /
-             (1_r + d2() + beta * d2_uncached(0, 0, k_offset) / gamma));
+  GT_FUNCTION static void apply(Evaluation eval,
+                                full_t::last_level::shift<-1>) {
+    auto f = eval(1_r / b());
+    eval(d1()) *= f;
+    eval(d2()) *= f;
   }
 
   template <typename Evaluation>
-  GT_FUNCTION static void apply(Evaluation eval, full_t::modify<1, -1>) {
-    eval(d()) = eval(d() - c() * d(0, 0, 1));
-    eval(d2()) = eval(d2() - c2() * d2(0, 0, 1));
+  GT_FUNCTION static void apply(Evaluation eval, full_t::modify<0, -2>) {
+    auto c = eval(-coeff() / (2_r * dz() * dz()));
+    auto f = eval(1_r / b());
+    eval(d1()) = eval((d1() - c * d1(0, 0, 1)) * f);
+    eval(d2()) = eval((d2() - c * d2(0, 0, 1)) * f);
   }
 };
 
 struct stage_diffusion_w3 {
   using out = inout_accessor<0>;
-  using x = in_accessor<1>;
-  using z = in_accessor<2>;
-  using fact = in_accessor<3>;
+  using out_top = inout_accessor<1, extent<0, 0, 0, 0, 0, 1>>;
+  using data = in_accessor<2, extent<0, 0, 0, 0, -infinite_extent, 0>>;
+  using d1 = in_accessor<3, extent<0, 0, 0, 0, -infinite_extent, 0>>;
+  using d2 = in_accessor<4, extent<0, 0, 0, 0, -infinite_extent, 0>>;
 
-  using param_list = make_param_list<out, x, z, fact>;
+  using dz = in_accessor<5>;
+  using dt = in_accessor<6>;
+  using coeff = in_accessor<7>;
+  using k_size = in_accessor<8>;
+
+  using param_list =
+      make_param_list<out, out_top, data, d1, d2, dz, dt, coeff, k_size>;
 
   template <typename Evaluation>
-  GT_FUNCTION static void apply(Evaluation eval, full_t) {
-    eval(out()) = eval(x() - fact() * z());
+  GT_FUNCTION static void apply(Evaluation eval, full_t::last_level) {
+    auto k_offset = eval(k_size() - 1);
+
+    auto a = eval(-coeff() / (2_r * dz() * dz()));
+    auto b = eval(1_r / dt() - 2 * a);
+    auto c = a;
+
+    auto d1_top =
+        eval(1_r / dt() * data() +
+             0.5_r * coeff() *
+                 (data(0, 0, -1) - 2_r * data() + data(0, 0, -k_offset)) /
+                 (dz() * dz()));
+
+    eval(out_top()) =
+        eval((d1_top - c * d1(0, 0, -k_offset) - a * d1(0, 0, -1)) /
+             (b + c * d2(0, 0, -k_offset) + a * d2(0, 0, -1)));
+    eval(out()) = eval(out_top());
+  }
+
+  template <typename Evaluation>
+  GT_FUNCTION static void apply(Evaluation eval, full_t::modify<0, -1>) {
+    eval(out_top()) = eval(out_top(0, 0, 1));
+    eval(out()) = eval(d1() + d2() * out_top());
   }
 };
 
@@ -221,49 +220,31 @@ std::function<void(storage_t, storage_t, real_t dt)>
 vertical(vec<std::size_t, 3> const &resolution, vec<real_t, 3> const &delta,
          real_t coeff) {
   auto grid = computation_grid(resolution.x, resolution.y, resolution.z);
-  auto const spec = [](auto out, auto in, auto in_uncached, auto fact, auto d,
-                       auto d2, auto d_uncached, auto d2_uncached, auto k_size,
+  auto const spec = [](auto out, auto in, auto in_uncached, auto k_size,
                        auto dz, auto dt, auto coeff) {
     using namespace gt::stencil;
-    GT_DECLARE_TMP(real_t, c, c2);
+    GT_DECLARE_TMP(real_t, b, d1, d2, out_top);
     return multi_pass(
         execute_forward()
             .k_cached(cache_io_policy::fill(), in)
-            .k_cached(cache_io_policy::flush(), c, d, c2, d2)
-            .stage(stage_diffusion_w_forward(), c, d, c2, d2, in, in_uncached,
-                   dz, dt, coeff, k_size),
+            .k_cached(cache_io_policy::flush(), b, d1, d2)
+            .stage(stage_diffusion_w_forward(), b, d1, d2, in, in_uncached, dz,
+                   dt, coeff, k_size),
         execute_backward()
-            .k_cached(cache_io_policy::fill(), cache_io_policy::flush(), d, d2)
-            .stage(stage_diffusion_w_backward(), c, d, c2, d2, fact, d_uncached,
-                   d2_uncached, dz, dt, coeff, k_size));
+            .k_cached(cache_io_policy::fill(), cache_io_policy::flush(), d1, d2)
+            .stage(stage_diffusion_w_backward(), b, d1, d2, dz, coeff),
+        execute_backward().k_cached(out_top).stage(stage_diffusion_w3(), out,
+                                                   out_top, in, d1, d2, dz, dt,
+                                                   coeff, k_size));
   };
 
-  auto field = storage_builder(resolution);
-
-  auto ij_slice = gt::storage::builder<storage_tr>
-    .type<real_t>()
-    .id<1>()
-    .halos(halo, halo)
-    .dimensions(resolution.x + 2 * halo, resolution.y + 2 * halo);
-
-  auto alpha = ij_slice();
-  auto gamma = ij_slice();
-  auto fact = ij_slice();
-  auto d = field();
-  auto d2 = field();
-
-  return [grid = std::move(grid), spec = std::move(spec),
-          fact = std::move(fact), d = std::move(d), d2 = std::move(d2), delta,
-          resolution, coeff](storage_t out, storage_t in, real_t dt) {
+  return [grid = std::move(grid), spec = std::move(spec), delta, resolution,
+          coeff](storage_t out, storage_t in, real_t dt) {
     gt::stencil::run(spec, backend_t<GTBENCH_BPARAMS_VDIFF1>(), grid, out, in,
-                     in, fact, d, d2, d, d2,
-                     gt::stencil::make_global_parameter(resolution.z),
+                     in, gt::stencil::make_global_parameter(resolution.z),
                      gt::stencil::make_global_parameter(delta.z),
                      gt::stencil::make_global_parameter(dt),
                      gt::stencil::make_global_parameter(coeff));
-    gt::stencil::run_single_stage(stage_diffusion_w3(),
-                                  backend_t<GTBENCH_BPARAMS_VDIFF2>(), grid,
-                                  out, d, d2, fact);
   };
 }
 

--- a/numerics/solver.hpp
+++ b/numerics/solver.hpp
@@ -81,7 +81,7 @@ inline auto hadv_stepper() {
             exchange = std::move(exchange)](solver_state &state,
                                             real_t dt) mutable {
       exchange(state.data);
-      hadv(state.data1, state.data, state.u, state.v, dt);
+      hadv(state.data1, state.data, state.data, state.u, state.v, dt);
       std::swap(state.data1, state.data);
     };
   };
@@ -91,7 +91,7 @@ inline auto vadv_stepper() {
   return [](solver_state const &state, exchange_t) {
     return [vadv = advection::vertical(state.resolution, state.delta)](
                solver_state &state, real_t dt) mutable {
-      vadv(state.data1, state.data, state.w, dt);
+      vadv(state.data1, state.data, state.data, state.w, dt);
       std::swap(state.data1, state.data);
     };
   };
@@ -99,18 +99,19 @@ inline auto vadv_stepper() {
 
 inline auto rkadv_stepper() {
   return [](solver_state const &state, exchange_t exchange) {
-    return [rkstep = advection::runge_kutta_step(state.resolution, state.delta),
+    return [hadv = advection::horizontal(state.resolution, state.delta),
+            vadv = advection::vertical(state.resolution, state.delta),
             exchange = std::move(exchange)](solver_state &state,
                                             real_t dt) mutable {
       exchange(state.data);
-      rkstep(state.data1, state.data, state.data, state.u, state.v, state.w,
-             dt / 3);
+      hadv(state.data1, state.data, state.data, state.u, state.v, dt / 3);
+      vadv(state.data1, state.data, state.data1, state.w, dt / 3);
       exchange(state.data1);
-      rkstep(state.data2, state.data1, state.data, state.u, state.v, state.w,
-             dt / 2);
+      hadv(state.data2, state.data1, state.data, state.u, state.v, dt / 2);
+      vadv(state.data2, state.data1, state.data2, state.w, dt / 2);
       exchange(state.data2);
-      rkstep(state.data, state.data2, state.data, state.u, state.v, state.w,
-             dt);
+      hadv(state.data1, state.data2, state.data, state.u, state.v, dt);
+      vadv(state.data, state.data2, state.data1, state.w, dt);
     };
   };
 }
@@ -121,7 +122,8 @@ inline auto advdiff_stepper(real_t diffusion_coeff) {
                                           diffusion_coeff),
             vdiff = diffusion::vertical(state.resolution, state.delta,
                                         diffusion_coeff),
-            rkstep = advection::runge_kutta_step(state.resolution, state.delta),
+            hadv = advection::horizontal(state.resolution, state.delta),
+            vadv = advection::vertical(state.resolution, state.delta),
             exchange = std::move(exchange)](solver_state &state,
                                             real_t dt) mutable {
       // VDIFF
@@ -130,14 +132,14 @@ inline auto advdiff_stepper(real_t diffusion_coeff) {
 
       // ADV
       exchange(state.data);
-      rkstep(state.data1, state.data, state.data, state.u, state.v, state.w,
-             dt / 3);
+      hadv(state.data1, state.data, state.data, state.u, state.v, dt / 3);
+      vadv(state.data1, state.data, state.data1, state.w, dt / 3);
       exchange(state.data1);
-      rkstep(state.data2, state.data1, state.data, state.u, state.v, state.w,
-             dt / 2);
+      hadv(state.data2, state.data1, state.data, state.u, state.v, dt / 2);
+      vadv(state.data2, state.data1, state.data2, state.w, dt / 2);
       exchange(state.data2);
-      rkstep(state.data, state.data2, state.data, state.u, state.v, state.w,
-             dt);
+      hadv(state.data1, state.data2, state.data, state.u, state.v, dt);
+      vadv(state.data, state.data2, state.data1, state.w, dt);
 
       // HDIFF
       exchange(state.data);

--- a/verification/analytical.hpp
+++ b/verification/analytical.hpp
@@ -95,13 +95,14 @@ struct horizontal_advection {};
 
 inline auto analytical_data(horizontal_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> real_t {
-    return std::sin(p.x - 5 * t) * std::cos(p.y + 2 * t) * std::cos(p.z);
+    return std::sin(p.x - 0.2_r * t) * std::cos(p.y + 0.3_r * t) *
+           std::cos(p.z);
   };
 }
 
 inline auto analytical_velocity(horizontal_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> vec<real_t, 3> {
-    return {5, -2, 0};
+    return {0.2_r, -0.3_r, 0};
   };
 }
 
@@ -109,13 +110,13 @@ struct vertical_advection {};
 
 inline auto analytical_data(vertical_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> real_t {
-    return std::sin(p.x) * std::cos(p.y) * std::cos(p.z - 3 * t);
+    return std::sin(p.x) * std::cos(p.y) * std::cos(p.z - 0.6_r * t);
   };
 }
 
 inline auto analytical_velocity(vertical_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> vec<real_t, 3> {
-    return {0, 0, 3};
+    return {0, 0, 0.6_r};
   };
 }
 
@@ -123,14 +124,14 @@ struct full_advection {};
 
 inline auto analytical_data(full_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> real_t {
-    return std::sin(p.x - 5 * t) * std::cos(p.y + 2 * t) *
-           std::cos(p.z - 3 * t);
+    return std::sin(p.x - 0.1_r * t) * std::cos(p.y + 0.2_r * t) *
+           std::cos(p.z - 0.3_r * t);
   };
 }
 
 inline auto analytical_velocity(full_advection const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> vec<real_t, 3> {
-    return {5, -2, 3};
+    return {0.1_r, -0.2_r, 0.3_r};
   };
 }
 
@@ -149,9 +150,9 @@ inline auto analytical_data(advection_diffusion const &advdiff) {
 inline auto analytical_velocity(advection_diffusion const &) {
   return [](vec<real_t, 3> const &p, real_t t) -> vec<real_t, 3> {
     const real_t a = std::sqrt(2_r) / 2;
-    return {-std::sin(p.x) * std::cos(a * (p.y - p.z)),
-            a * std::cos(p.x) * std::sin(a * (p.y - p.z)),
-            -a * std::cos(p.x) * std::sin(a * (p.y - p.z))};
+    return {-std::sin(p.x) * std::cos(a * (p.y - p.z)) * 0.1_r,
+            a * std::cos(p.x) * std::sin(a * (p.y - p.z)) * 0.1_r,
+            -a * std::cos(p.x) * std::sin(a * (p.y - p.z)) * 0.1_r};
   };
 }
 

--- a/verification/convergence.hpp
+++ b/verification/convergence.hpp
@@ -43,9 +43,9 @@ order_verification_result_t order_verification(F &&f, std::size_t n_min,
 
 void print_order_verification_result(
     order_verification_result_t const &result) {
-  std::vector<std::size_t> ns;
-  std::vector<double> errors, orders;
-  std::tie(ns, errors, orders) = result;
+  auto const &ns = std::get<0>(result);
+  auto const &errors = std::get<1>(result);
+  auto const &orders = std::get<2>(result);
 
   const auto initial_flags = std::cout.flags();
   const auto initial_precision = std::cout.precision();
@@ -65,6 +65,17 @@ void print_order_verification_result(
 
   std::cout.flags(initial_flags);
   std::cout.precision(initial_precision);
+}
+
+bool check_order(order_verification_result_t const &result,
+                 real_t expected_order, real_t atol, real_t rtol) {
+  auto const &orders = std::get<2>(result);
+  for (auto order : orders) {
+    if (std::abs(order - expected_order) <=
+        atol + rtol * std::abs(expected_order))
+      return true;
+  }
+  return false;
 }
 
 } // namespace verification


### PR DESCRIPTION
- Fixes vertical advection and vertical diffusion to be 2nd order in time.
- New solver implementation without 2D fields.
- Un-fused horizontal and vertical advection in Runge-Kutta integrator.
- More accurate convergence checks.
- Convergence check binary now returns an error on failure.
- Changes will impact performance (in a positive or negative way, depending on the hardware).