### PR TITLE
Updated README and CMake Version Requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.18.1)
 
 file(STRINGS "version.txt" _gtbench_version)
 project(GTBench VERSION ${_gtbench_version} LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ To enable xpmem support, pass additionally the following flags
 
 ### Benchmark
 
-The benchmark executable requires the global horizontal domain size as a command line parameter. The simulation will then be performed on a total domain size of `NX×NY×60` grid points. To launch the benchmark use the appropriate MPI launcher (`mpirun`, `mpiexec`, `srun`, or similar):
+The benchmark executable requires the domain size as a command line parameter. The simulation will then be performed on a total domain size of `NX×NY×NZ` grid points. To launch the benchmark use the appropriate MPI launcher (`mpirun`, `mpiexec`, `srun`, or similar):
 ```console
-$ mpi_launcher <LAUNCHER_OPTIONS> ./benchmark --domain-size <NX> <NY>
+$ mpi_launcher <LAUNCHER_OPTIONS> ./benchmark --domain-size <NX> <NY> <NZ>
 ```
 
 Example output of a single-node benchmark run:
@@ -106,11 +106,11 @@ Columns per second:      50484.1 (95% confidence: 49908.1 - 50622.6)
 
 For testing, the number of runs (and thus the run time) can be reduced as follows:
 ```console
-$ mpi_launcher <LAUNCHER_OPTIONS> ./benchmark --domain-size <N> <NY> --runs <RUNS>
+$ mpi_launcher <LAUNCHER_OPTIONS> ./benchmark --domain-size <NX> <NY> <NZ> --runs <RUNS>
 ```
 For example, run only once:
 ```console
-$ mpi_launcher ./benchmark --domain-size 24000 24000 --runs 1
+$ mpi_launcher ./benchmark --domain-size 24000 24000 60 --runs 1
 Running GTBENCH
 Domain size:             24000x24000x60
 Floating-point type:     float

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The backend can be selected by setting the `GTBENCH_BACKEND` option when configu
 ```console
 $ cmake -DGTBENCH_BACKEND=<BACKEND> ..
 ```
-where `<BACKEND>` must be either `cpu_kfirst`, `cpu_ifirst`, or `gpu`. The `cpu_kfirst` and `cpu_ifirst` backends are two different CPU-backends of GridTools. On modern CPUs with large vector width and/or many cores, the `cpu_ifirst` backend might perform significantly better. On CPUs without vectorization or small vector width and limited parallelism, the `cpu_kfirst` backend might perform better. The `hip` backend currently supports running NVIDIA CUDA-capable GPUs and AMD HIP-capable GPUs.
+where `<BACKEND>` must be either `cpu_kfirst`, `cpu_ifirst`, or `gpu`. The `cpu_kfirst` and `cpu_ifirst` backends are two different CPU-backends of GridTools. On modern CPUs with large vector width and/or many cores, the `cpu_ifirst` backend might perform significantly better. On CPUs without vectorization or small vector width and limited parallelism, the `cpu_kfirst` backend might perform better. The `gpu` backend currently supports running NVIDIA CUDA-capable GPUs and AMD HIP-capable GPUs.
 
 ### Selecting the GPU Compilation Framework
 
@@ -56,7 +56,7 @@ where `RUNTIME` can be `ghex_comm`, `gcl`, `simple_mpi`, `single_node`.
 - The `simple_mpi` implementation uses a simple MPI 2 sided communication for halo exchanges.
 - The `gcl` implementation uses a optimized MPI based communication library shipped with [GridTools](https://gridtools.github.io/gridtools/latest/user_manual/user_manual.html#halo-exchanges).
 - The `ghex_comm` option will use highly optimized distributed communication via the GHEX library, designed for best performance at scale.
- Additionally, this option will enable a multi-threaded version of the benchmark, where a rank may have more than one sub-domain (over-subscription), which are delegated to separate threads. **Note:** The gridtools computations use openmp threads on the CPU targets which will not be affected by this parameter.
+ Additionally, this option will enable a multi-threaded version of the benchmark, where a rank may have more than one sub-domain (over-subscription), which are delegated to separate threads. **Note:** The gridtools computations use OpenMP threads on the CPU targets which will not be affected by this parameter.
 
 #### Selecting the Transport Layer for GHEX
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ be installed automatically when building GT Bench with cmake unless specified ot
 
 Further external dependencies are listed below:
 Required:
-- [CMake](https://cmake.org/) (minimum version 3.14.5)
-- [Boost](https://www.boost.org/) (minimun version 1.73.0)
+- [CMake](https://cmake.org/) (minimum version 3.18.1)
+- [Boost](https://www.boost.org/) (minimum version 1.73.0)
 - MPI (for example [OpenMPI](https://github.com/open-mpi/ompi))
 
 Optional:


### PR DESCRIPTION
Fixed out-of-date information in the README and updated the CMake minimum version requirement to the one of GridTools 2.2.