### PR TITLE
Added libnuma-dev to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update -qq && \
     libmpich-dev \
     tar \
     software-properties-common \
-    wget && \
+    wget \
+    libnuma-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ARG CMAKE_VERSION=3.18.4


### PR DESCRIPTION
Needed for hwmalloc, on which GHEX depends