### PR TITLE
Update cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.1)
+cmake_minimum_required(VERSION 3.24)
 
 file(STRINGS "version.txt" _gtbench_version)
 project(GTBench VERSION ${_gtbench_version} LANGUAGES CXX)


### PR DESCRIPTION
cmake_minimum_required is outdated because of https://github.com/lukasm91/gtbench/blob/master/CMakeLists.txt#L60

This was added in CMake 3.24: https://cmake.org/cmake/help/latest/module/FetchContent.html

The error with CMake 3.22 is absolutely useless:

```
CMake Error at /gtbench/_deps/gridtools-subbuild/gridtools-populate-prefix/tmp/gridtools-populate-gitupdate.cmake:25 (message):
  Failed to get the hash for HEAD:

```